### PR TITLE
Support arrays by whitespace and nested arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,23 @@ import warning from 'warning'
  * @return {Boolean} flag, indicating function was successfull or not
  */
 function setClass(rule, composition) {
+  /* Skip falsy values */
+  if (!composition) return true
+
+  if (Array.isArray(composition)) {
+    for (let index = 0; index < composition.length; index++) {
+      const isSetted = setClass(rule, composition[index])
+
+      if (!isSetted) return false
+    }
+
+    return true
+  }
+
+  if (composition.includes(' ')) {
+    return setClass(rule, composition.split(' '))
+  }
+
   if (composition[0] === '$') {
     const refRule = rule.options.sheet.getRule(composition.substr(1))
 
@@ -41,12 +58,7 @@ export default function jssCompose() {
 
     if (!style || !style.composes) return
 
-    if (Array.isArray(style.composes)) {
-      for (let index = 0; index < style.composes.length; index++) {
-        setClass(rule, style.composes[index])
-      }
-    }
-    else setClass(rule, style.composes)
+    setClass(rule, style.composes)
 
     // Remove composes property to prevent infinite loop.
     delete style.composes

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import warning from 'warning'
  * @return {Boolean} flag, indicating function was successfull or not
  */
 function setClass(rule, composition) {
-  /* Skip falsy values */
+  // Skip falsy values
   if (!composition) return true
 
   if (Array.isArray(composition)) {
@@ -21,7 +21,7 @@ function setClass(rule, composition) {
     return true
   }
 
-  if (composition.includes(' ')) {
+  if (composition.indexOf(' ') > -1) {
     return setClass(rule, composition.split(' '))
   }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -112,6 +112,14 @@ describe('jss-compose', () => {
         d: {
           composes: ['$a', '$b', '$c'],
           border: 'none'
+        },
+        e: {
+          composes: '$a $b $c',
+          border: 'none'
+        },
+        f: {
+          composes: ['$a', ['$b', '$c']],
+          border: 'none'
         }
       })
     })
@@ -125,11 +133,17 @@ describe('jss-compose', () => {
       expect(sheet.getRule('b')).to.not.be(undefined)
       expect(sheet.getRule('c')).to.not.be(undefined)
       expect(sheet.getRule('d')).to.not.be(undefined)
+      expect(sheet.getRule('e')).to.not.be(undefined)
+      expect(sheet.getRule('f')).to.not.be(undefined)
     })
 
     it('should compose classes', () => {
       expect(sheet.getRule('d').className)
         .to.be('d-id a-id b-id c-id')
+      expect(sheet.getRule('e').className)
+        .to.be('e-id a-id b-id c-id')
+      expect(sheet.getRule('f').className)
+        .to.be('f-id a-id b-id c-id')
     })
 
     it('should generate correct CSS', () => {
@@ -144,6 +158,12 @@ describe('jss-compose', () => {
         '  background: blue;\n' +
         '}\n' +
         '.d-id {\n' +
+        '  border: none;\n' +
+        '}\n' +
+        '.e-id {\n' +
+        '  border: none;\n' +
+        '}\n' +
+        '.f-id {\n' +
         '  border: none;\n' +
         '}'
       )
@@ -161,6 +181,10 @@ describe('jss-compose', () => {
         b: {
           composes: ['$a', 'c', 'd'],
           color: 'red'
+        },
+        e: {
+          composes: '$a c d',
+          color: 'red'
         }
       })
     })
@@ -172,10 +196,12 @@ describe('jss-compose', () => {
     it('should add rules', () => {
       expect(sheet.getRule('a')).to.not.be(undefined)
       expect(sheet.getRule('b')).to.not.be(undefined)
+      expect(sheet.getRule('e')).to.not.be(undefined)
     })
 
     it('should compose classes', () => {
       expect(sheet.getRule('b').className).to.be('b-id a-id c d')
+      expect(sheet.getRule('e').className).to.be('e-id a-id c d')
     })
 
     it('should generate correct CSS', () => {
@@ -184,6 +210,9 @@ describe('jss-compose', () => {
         '  float: left;\n' +
         '}\n' +
         '.b-id {\n' +
+        '  color: red;\n' +
+        '}\n' +
+        '.e-id {\n' +
         '  color: red;\n' +
         '}'
       )


### PR DESCRIPTION
It seems to be useful:

### Whitespaces

```js
style: {
  composes: '$a $b $c',
  border: 'none'
}
```

### Nested arrays

```js
style: {
  composes: ['$a', ['$b', '$c']],
  border: 'none'
}
```

### Skip falsy values
```js
style: {
  composes: ['$a', isSmth && '$d'],
  border: 'none'
}
```